### PR TITLE
Added final Mordor configuration changes for Hyperledger Besu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ geth --networkid 7 --port 32000
 
 _Mantis no longer supports Ethereum Classic chains._
 
-### Hyperledger Besu (a.k.a. Pantheon)
+### Hyperledger Besu
 
-_Besu does not support Ethereum Classic yet._
+Minimum required version: `v1.3.7`
+
+```
+besu --genesis-file=./besu.json --port 33000
+```

--- a/besu.json
+++ b/besu.json
@@ -1,12 +1,6 @@
 {
   "config": {
     "chainId": 63,
-    "homesteadBlock": 0,
-    "classicForkBlock": 0,
-    "ecip1015Block": 0,
-    "diehardBlock": 0,
-    "gothamBlock": 0,
-    "ecip1041Block": 0,
     "atlantisBlock": 0,
     "aghartaBlock": 301243,
     "ethash": {}


### PR DESCRIPTION
The zeroed config entries were removed in the Besu repo as well, because they were triggering some issues.
Maybe something related to the fact that Atlantis was the first HF supported by Besu?
Whatever the case, this is the correct configuration to use.