### PR TITLE
Removed besu.json entries which cause issues.  Minor updates to client names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _Launch: October 3, 2019 at ETCSummit. [eth-classic/mordor#1](https://github.com
 0xa68ebde7932eccb177d38d55dcc6461a019dd795a681e59b5a3e4f3a7259a3f1
 ```
 
-### Parity Ethereum
+### Parity-Ethereum
 
 Minimum required version: `v2.5.10`
 
@@ -60,7 +60,7 @@ Minimum required version: `v1.9.4`
 geth --mordor
 ```
 
-### Hyperledger Besu (a.k.a. Pantheon)
+### Hyperledger Besu
 
 Minimum required version: `v1.3.6`
 

--- a/besu.json
+++ b/besu.json
@@ -1,12 +1,6 @@
 {
   "config": {
     "chainId": 63,
-    "homesteadBlock": 0,
-    "classicForkBlock": 0,
-    "ecip1015Block": 0,
-    "diehardBlock": 0,
-    "gothamBlock": 0,
-    "ecip1041Block": 0,
     "atlantisBlock": 0,
     "aghartaBlock": 301243,
     "ethash": {}


### PR DESCRIPTION
Removed besu.json entries which cause issues (presumably because there was no ETC support prior to Atlantis?)

This JSON file matches the one shipped with HL Besu.

Removed the "a.k.a. Pantheon".  The new name is well known now, and we want NOT to be talking about Pantheon.
"Parity-Ethereum" vs "Parity Ethereum"

Is there any value in maintaining the copies of the JSON files in this repo after built-in config support for Mordor has been added to each of these clients, and our example command-lines are NOT using these local files?